### PR TITLE
Addfeatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Add these lines to the `.vimrc`:
 
 The `:Papis` command will open a search window for your bibliographic database. `Enter` command will insert citation for the selected record in the current buffer.
 
+The `:PapisView` command will open the pdf file of the citation currently under your cursor with the same pdf-reader used by papis. 
+This currently only works when using whoosh as backend for the papis database. Add the following to your `config` file of papis:
+
+    database-backend = whoosh
+    whoosh-schema-fields = ['ref']
+
+The second is needed to enable whoosh for searches through the ref field.
+
+
+Add the following to your `tex.vim` file for useful keyboard shortcuts:
+
+    nnoremap <buffer> <localleader>pc :Papis<cr>
+    nnoremap <buffer> <localleader>pv :PapisView<cr>
+
 ## Documentation
 
 For more information, execute `:help papis` in Vim.

--- a/plugin/papis.vim
+++ b/plugin/papis.vim
@@ -10,9 +10,9 @@ function! s:get_reference(line)
 endfunction
 
 function! s:inside_cite_body()
-  execute "silent! normal mq?\\\\cite\\|}\r"
+  execute "silent! normal! mq?\\\\cite\\|}\r"
   let l:inbody = getline('.')[col('.')-1: col('.') + 3] ==# '\cite'
-  execute "normal `q"
+  execute "normal! `q"
   return l:inbody
 endfunction
 
@@ -39,15 +39,60 @@ function! s:handler(a)
   else
     " If you are already in a \cite{} body
     if s:inside_cite_body()
-      execute "normal \/\}\rgea, " . join(l:candidates, ", ") ."\e"
+      execute "normal! \/\}\rgea, " . join(l:candidates, ", ") ."\e"
     " start a fresh \cite{} body
     else
-      execute "normal a\\cite{" . join(l:candidates, ", ") . "}\e"
+      execute "normal! a\\cite{" . join(l:candidates, ", ") . "}\e"
     endif
   endif
 endfunction
 
 let g:PapisFormat = '"{doc[author]}: {doc[title]}'
+let g:PapisBackend = 'whoosh'
 
 command! -bang -nargs=* Papis
-      \ call fzf#run(fzf#wrap({'source': 'papis list <args> --format ' . g:PapisFormat . ' @{doc[ref]}"', 'sink*': function('<sid>handler'), 'options': '--multi --expect=ctrl-y --print-query'}))
+      \ call fzf#run(fzf#wrap({'source': 'papis list "*" <args> --format ' . g:PapisFormat . ' @{doc[ref]}"', 'sink*': function('<sid>handler'), 'options': '--multi --expect=ctrl-y --print-query'}))
+
+function! s:get_citeref(cite, full_list)
+  for l:ref in a:full_list
+    if a:cite ==# substitute(l:ref, "/", "", "g")
+      return l:ref
+    endif
+  endfor
+endfunction
+
+function! s:get_all_citerefs()
+  return systemlist('papis list "ref:*" --format "{doc[ref]}"')
+endfunction
+
+function! s:get_cite_under_cursor()
+  if s:inside_cite_body()
+    if getline('.')[col('.') -1] ==# ','
+      return
+    endif
+
+    execute "silent! normal! mq/[}{]\r"
+    if getline('.')[col('.') -1] ==# '{'
+      execute "silent! normal! `q"
+      return
+    endif
+
+    execute "silent! normal! `q"
+    execute "silent! normal! ?[{,]\rwv/[,}]\rge\"qy`q"
+    return @q
+  endif
+endfunction
+
+function! s:PapisView()
+  let l:cite = s:get_cite_under_cursor()
+  if l:cite ==# ""
+    return
+  endif
+
+  let l:full_list = s:get_all_citerefs()
+  let l:ref = s:get_citeref(l:cite, l:full_list)
+  call system('papis open "ref:' . l:ref . '"')
+endfunction
+
+command! -bang PapisView
+      \ call s:PapisView()

--- a/plugin/papis.vim
+++ b/plugin/papis.vim
@@ -26,14 +26,11 @@ function! s:handler(a)
     let candidates = []
     for line in citations
       let id = matchlist(line, pat)[1]
-      call add(candidates, "\\cite{". id . "}")
+      call add(candidates, substitute(id, "/", "", "g"))
     endfor
   endif
 
-  for candidate in candidates
-    execute join([cmd, candidate])
-  endfor
-
+  execute "normal a\\cite{" . join(candidates, ", ") . "}\egql"
 endfunction
 
 


### PR DESCRIPTION
Add PapisView command, which opens the pdf of the citation your cursor is on in vim at that moment.
Works only with whoosh though, since searching by ref does not seem to work for me with the papis backend.

Changed :Papis command since the bibtex export op papis generates as label the ref-field minus every '/', apparently. It also adds multiple citations in the same cite body instead of several different ones.

Love papis btw!

