### PR TITLE
Retrieve whole list of references to bypass picktool

### DIFF
--- a/plugin/papis.vim
+++ b/plugin/papis.vim
@@ -78,7 +78,7 @@ function! s:get_citeref(cite, full_list)
 endfunction
 
 function! s:get_all_citerefs()
-  return systemlist('papis list "ref:*" --format "{doc[ref]}"')
+  return systemlist('papis list "ref:*" --format "{doc[ref]}" --all')
 endfunction
 
 function! s:get_cite_under_cursor()


### PR DESCRIPTION
`:PapisView` did not work since `papis list` by default returns a list that is incomprehensible for vim due to the picktool. The `--all` option bypasses the picktool and therefore makes `:PapisView` work again.